### PR TITLE
chore(docs): fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ function Wallet() {
   return (
     <div>
       {account ? `Connected to ${account.bech32Address}` : status}
-      <button onClick={handleConnect}>{isConnected ? "Connect" : "Disconnect"}</button>
+      <button onClick={handleConnect}>{isConnected ? "Disconnect" : "Connect"}</button>
     </div>
   );
 }


### PR DESCRIPTION
Simple typo in the README has the boolean check the wrong way round, if isConnected == true we should display Disconnect else display connect