### PR TITLE
feat(actions): add optional gas config and pass signer opts

### DIFF
--- a/packages/graz/package.json
+++ b/packages/graz/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.28.10",
+    "@cosmjs/stargate": "^0.28.10",
     "@cosmjs/proto-signing": "^0.28.10",
     "@keplr-wallet/cosmos": "^0.10.10",
     "@keplr-wallet/types": "^0.10.10",

--- a/packages/graz/package.json
+++ b/packages/graz/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.28.10",
-    "@cosmjs/stargate": "^0.28.10",
     "@cosmjs/proto-signing": "^0.28.10",
+    "@cosmjs/stargate": "^0.28.10",
     "@keplr-wallet/cosmos": "^0.10.10",
     "@keplr-wallet/types": "^0.10.10",
     "react-query": "^3",

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -1,3 +1,4 @@
+import type { SigningCosmWasmClientOptions } from "@cosmjs/cosmwasm-stargate";
 import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { GasPrice } from "@cosmjs/stargate";
 
@@ -5,7 +6,7 @@ import type { GrazChain } from "../chains";
 import { getKeplr } from "../keplr";
 import { defaultValues, useGrazStore } from "../store";
 
-export async function connect(chain: GrazChain) {
+export async function connect(chain: GrazChain, signerOpts: SigningCosmWasmClientOptions = {}) {
   try {
     const keplr = getKeplr();
 
@@ -28,6 +29,7 @@ export async function connect(chain: GrazChain) {
       await keplr.getOfflineSignerAuto(chain.chainId),
       await SigningCosmWasmClient.connectWithSigner(chain.rpc, signer, {
         gasPrice: chain.gas ? GasPrice.fromString(`${chain.gas.price}${chain.gas.denom}`) : undefined,
+        ...signerOpts,
       }),
     ] as const);
 

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -1,4 +1,5 @@
 import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import { GasPrice } from "@cosmjs/stargate";
 
 import type { GrazChain } from "../chains";
 import { getKeplr } from "../keplr";
@@ -25,7 +26,10 @@ export async function connect(chain: GrazChain) {
     const [account, signerAuto, client] = await Promise.all([
       await keplr.getKey(chain.chainId),
       await keplr.getOfflineSignerAuto(chain.chainId),
-      await SigningCosmWasmClient.connectWithSigner(chain.rpc, signer),
+      await SigningCosmWasmClient.connectWithSigner(chain.rpc, signer, {
+        gasPrice:
+          chain.gasPrice && chain.gasDenom ? GasPrice.fromString(`${chain.gasPrice}${chain.gasDenom}`) : undefined,
+      }),
     ] as const);
 
     useGrazStore.setState({

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -27,8 +27,7 @@ export async function connect(chain: GrazChain) {
       await keplr.getKey(chain.chainId),
       await keplr.getOfflineSignerAuto(chain.chainId),
       await SigningCosmWasmClient.connectWithSigner(chain.rpc, signer, {
-        gasPrice:
-          chain.gasPrice && chain.gasDenom ? GasPrice.fromString(`${chain.gasPrice}${chain.gasDenom}`) : undefined,
+        gasPrice: chain.gas ? GasPrice.fromString(`${chain.gas.price}${chain.gas.denom}`) : undefined,
       }),
     ] as const);
 

--- a/packages/graz/src/chains/index.ts
+++ b/packages/graz/src/chains/index.ts
@@ -9,8 +9,10 @@ export interface GrazChain {
   currencies: AppCurrency[];
   rest: string;
   rpc: string;
-  gasPrice?: string;
-  gasDenom?: string;
+  gas?: {
+    price: string;
+    denom: string;
+  };
 }
 
 export function defineChains<T extends Record<string, GrazChain>>(chains: T) {

--- a/packages/graz/src/chains/index.ts
+++ b/packages/graz/src/chains/index.ts
@@ -9,6 +9,8 @@ export interface GrazChain {
   currencies: AppCurrency[];
   rest: string;
   rpc: string;
+  gasPrice?: string;
+  gasDenom?: string;
 }
 
 export function defineChains<T extends Record<string, GrazChain>>(chains: T) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,7 +937,7 @@
     ws "^7"
     xstream "^11.14.0"
 
-"@cosmjs/stargate@0.28.10":
+"@cosmjs/stargate@0.28.10", "@cosmjs/stargate@^0.28.10":
   version "0.28.10"
   resolved "https://registry.yarnpkg.com/@cosmjs/stargate/-/stargate-0.28.10.tgz#b0a1fbf08fb18eb36970e097d85f5d6de8e8166a"
   integrity sha512-KFDcc/LeTBnipGUKbtre9d0mBy2gNvqf82AZ+j9q7QXOKuPmvraVfZGfombGWq4AImtZZdytEFO196epKq9CtQ==


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

Closes #7 
This PR adds optional gas configurations for the CosmWasmClient allowing users to define `GrazChain` with `gasPrice` and `gasDenom` this allows the "auto" gas flag to be used when making CosmWasm TXs.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

- Added `gasPrice` and `gasDenom` to `GrazChain` although these are optional.
- Added `GasPrice.fromString` when creating the CosmWasmClient in the hooks.
