### PR TITLE
chore(docs): fix api typo

### DIFF
--- a/API.md
+++ b/API.md
@@ -385,7 +385,7 @@ const osmosisTestnet = {
   bip44: {
     coinType: 118,
   },
-  bech32Config: bech32Config: Bech32Address.defaultBech32Config("osmo"),
+  bech32Config: Bech32Address.defaultBech32Config("osmo"),
   currencies: [OSMO],
   feeCurrencies: [OSMO],
   coinType: 118,


### PR DESCRIPTION
Small typo in the API at [useSuggestChain](https://github.com/strangelove-ventures/graz/blob/dev/API.md#usesuggestchain).

`bech32Config: bech32Config: Bech32Address.defaultBech32Config("osmo"),`
-> `bech32Config: Bech32Address.defaultBech32Config("osmo"),`