### PR TITLE
CosmWasm smart contract hooks

### DIFF
--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -168,34 +168,22 @@ export const executeContract = async <Message extends Record<string, unknown>>({
   return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee);
 };
 
-export const getQuerySmart = async <TData>(address?: string, queryMsg?: Record<string, unknown>): Promise<TData> => {
+export const getQuerySmart = async <TData>(address: string, queryMsg: Record<string, unknown>): Promise<TData> => {
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
     throw new Error("CosmWasm signing client is not ready");
-  }
-
-  if (address === undefined) {
-    throw new Error("Contract address is undefined");
-  }
-
-  if (queryMsg === undefined) {
-    throw new Error("Query message is undefined");
   }
 
   const result = (await signingClients.cosmWasm.queryContractSmart(address, queryMsg)) as TData;
   return result;
 };
 
-export const getQueryRaw = (keyStr: string, address?: string): Promise<Uint8Array | null> => {
+export const getQueryRaw = (address: string, keyStr: string): Promise<Uint8Array | null> => {
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
     throw new Error("CosmWasm signing client is not ready");
-  }
-
-  if (address === undefined) {
-    throw new Error("Contract address is undefined");
   }
 
   const key = new TextEncoder().encode(keyStr);

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -168,11 +168,19 @@ export const executeContract = async <Message extends Record<string, unknown>>({
   return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee);
 };
 
-export const getQuerySmart = async <TData>(address: string, queryMsg: Record<string, unknown>): Promise<TData> => {
+export const getQuerySmart = async <TData>(address?: string, queryMsg?: Record<string, unknown>): Promise<TData> => {
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
     throw new Error("Stargate signing client is not ready");
+  }
+
+  if (address === undefined) {
+    throw new Error("Contract address is undefined");
+  }
+
+  if (queryMsg === undefined) {
+    throw new Error("Query message is undefined");
   }
 
   return (await signingClients.cosmWasm.queryContractSmart(address, queryMsg)) as TData;

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -129,9 +129,6 @@ export const instantiateContract = async <Message extends Record<string, unknown
   if (!signingClients?.cosmWasm) {
     throw new Error("CosmWasm signing client is not ready");
   }
-  if (!senderAddress) {
-    throw new Error("senderAddress is not defined");
-  }
 
   return signingClients.cosmWasm.instantiate(senderAddress, codeId, msg, label, fee, options);
 };
@@ -160,9 +157,6 @@ export const executeContract = async <Message extends Record<string, unknown>>({
 
   if (!signingClients?.cosmWasm) {
     throw new Error("CosmWasm signing client is not ready");
-  }
-  if (!senderAddress) {
-    throw new Error("senderAddress is not defined");
   }
 
   return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee);

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -167,3 +167,23 @@ export const executeContract = async <Message extends Record<string, unknown>>({
 
   return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee);
 };
+
+export const getQuerySmart = async <TData>(address: string, queryMsg: Record<string, unknown>): Promise<TData> => {
+  const { signingClients } = useGrazStore.getState();
+
+  if (!signingClients?.cosmWasm) {
+    throw new Error("Stargate signing client is not ready");
+  }
+
+  return (await signingClients.cosmWasm.queryContractSmart(address, queryMsg)) as TData;
+};
+
+export const getQueryRaw = async <TData>(address: string, key: Uint8Array): Promise<TData> => {
+  const { signingClients } = useGrazStore.getState();
+
+  if (!signingClients?.cosmWasm) {
+    throw new Error("Stargate signing client is not ready");
+  }
+
+  return (await signingClients.cosmWasm.queryContractRaw(address, key)) as TData;
+};

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -1,3 +1,4 @@
+import type { InstantiateOptions } from "@cosmjs/cosmwasm-stargate";
 import type { Coin } from "@cosmjs/proto-signing";
 import type { DeliverTxResponse, StdFee } from "@cosmjs/stargate";
 import type { Height } from "cosmjs-types/ibc/core/client/v1/client";
@@ -97,4 +98,40 @@ export const sendIbcTokens = async ({
     fee,
     memo,
   );
+};
+
+export interface InstantiateContractArgs<Message extends Record<string, unknown>> {
+  msg: Message;
+  label: string;
+  fee: StdFee | "auto" | number;
+  options?: InstantiateOptions;
+  senderAddress?: string;
+  codeId: number;
+}
+
+export type InstantiateContractMutationArgs<Message extends Record<string, unknown>> = Omit<
+  InstantiateContractArgs<Message>,
+  "codeId" | "senderAddress" | "fee"
+> & {
+  fee?: StdFee | "auto" | number;
+};
+
+export const instantiateContract = async <Message extends Record<string, unknown>>({
+  senderAddress,
+  msg,
+  fee,
+  options,
+  label,
+  codeId,
+}: InstantiateContractArgs<Message>) => {
+  const { signingClients } = useGrazStore.getState();
+
+  if (!signingClients?.cosmWasm) {
+    throw new Error("Stargate signing client is not ready");
+  }
+  if (!senderAddress) {
+    throw new Error("senderAddress is not defined");
+  }
+
+  return signingClients.cosmWasm.instantiate(senderAddress, codeId, msg, label, fee, options);
 };

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -183,15 +183,21 @@ export const getQuerySmart = async <TData>(address?: string, queryMsg?: Record<s
     throw new Error("Query message is undefined");
   }
 
-  return (await signingClients.cosmWasm.queryContractSmart(address, queryMsg)) as TData;
+  const result = (await signingClients.cosmWasm.queryContractSmart(address, queryMsg)) as TData;
+  return result;
 };
 
-export const getQueryRaw = async <TData>(address: string, key: Uint8Array): Promise<TData> => {
+export const getQueryRaw = (keyStr: string, address?: string): Promise<Uint8Array | null> => {
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
     throw new Error("Stargate signing client is not ready");
   }
 
-  return (await signingClients.cosmWasm.queryContractRaw(address, key)) as TData;
+  if (address === undefined) {
+    throw new Error("Contract address is undefined");
+  }
+
+  const key = new TextEncoder().encode(keyStr);
+  return signingClients.cosmWasm.queryContractRaw(address, key);
 };

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -127,7 +127,7 @@ export const instantiateContract = async <Message extends Record<string, unknown
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
-    throw new Error("Stargate signing client is not ready");
+    throw new Error("CosmWasm signing client is not ready");
   }
   if (!senderAddress) {
     throw new Error("senderAddress is not defined");
@@ -159,7 +159,7 @@ export const executeContract = async <Message extends Record<string, unknown>>({
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
-    throw new Error("Stargate signing client is not ready");
+    throw new Error("CosmWasm signing client is not ready");
   }
   if (!senderAddress) {
     throw new Error("senderAddress is not defined");
@@ -172,7 +172,7 @@ export const getQuerySmart = async <TData>(address?: string, queryMsg?: Record<s
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
-    throw new Error("Stargate signing client is not ready");
+    throw new Error("CosmWasm signing client is not ready");
   }
 
   if (address === undefined) {
@@ -191,7 +191,7 @@ export const getQueryRaw = (keyStr: string, address?: string): Promise<Uint8Arra
   const { signingClients } = useGrazStore.getState();
 
   if (!signingClients?.cosmWasm) {
-    throw new Error("Stargate signing client is not ready");
+    throw new Error("CosmWasm signing client is not ready");
   }
 
   if (address === undefined) {

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -135,3 +135,35 @@ export const instantiateContract = async <Message extends Record<string, unknown
 
   return signingClients.cosmWasm.instantiate(senderAddress, codeId, msg, label, fee, options);
 };
+
+export interface ExecuteContractArgs<Message extends Record<string, unknown>> {
+  msg: Message;
+  fee: StdFee | "auto" | number;
+  senderAddress?: string;
+  contractAddress: string;
+}
+
+export type ExecuteContractMutationArgs<Message extends Record<string, unknown>> = Omit<
+  ExecuteContractArgs<Message>,
+  "contractAddress" | "senderAddress" | "fee"
+> & {
+  fee?: StdFee | "auto" | number;
+};
+
+export const executeContract = async <Message extends Record<string, unknown>>({
+  senderAddress,
+  msg,
+  fee,
+  contractAddress,
+}: ExecuteContractArgs<Message>) => {
+  const { signingClients } = useGrazStore.getState();
+
+  if (!signingClients?.cosmWasm) {
+    throw new Error("Stargate signing client is not ready");
+  }
+  if (!senderAddress) {
+    throw new Error("senderAddress is not defined");
+  }
+
+  return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee);
+};

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -105,7 +105,7 @@ export interface InstantiateContractArgs<Message extends Record<string, unknown>
   label: string;
   fee: StdFee | "auto" | number;
   options?: InstantiateOptions;
-  senderAddress?: string;
+  senderAddress: string;
   codeId: number;
 }
 
@@ -139,7 +139,7 @@ export const instantiateContract = async <Message extends Record<string, unknown
 export interface ExecuteContractArgs<Message extends Record<string, unknown>> {
   msg: Message;
   fee: StdFee | "auto" | number;
-  senderAddress?: string;
+  senderAddress: string;
   contractAddress: string;
 }
 

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -212,7 +212,9 @@ export const useQuerySmart = <TQueryFnData, TError, TData>(
   queryMsg: Record<string, unknown>,
   options?: QueryOptions<TQueryFnData, TError, TData, QuerySmartKey>,
 ): UseQueryResult<TData, TError> => {
-  //TODO: error handling and options defaulting
+  const queryOptions: QueryOptions<TQueryFnData, TError, TData, QuerySmartKey> = options || {
+    enabled: Boolean(address),
+  };
 
   const queryKey: QuerySmartKey = ["USE_QUERY_SMART", address, queryMsg] as const;
   const query = useQuery(queryKey, ({ queryKey: [, _address] }) => getQuerySmart(address, queryMsg), options);
@@ -227,7 +229,7 @@ export const useQueryRaw = <TQueryFnData, TError, TData>(
   key: Uint8Array,
   options?: QueryOptions<TQueryFnData, TError, TData, QueryRawKey>,
 ): UseQueryResult<TData, TError> => {
-  //TODO: error handling and options defaulting
+  const queryOptions: QueryOptions<TQueryFnData, TError, TData, QueryRawKey> = options || { enabled: Boolean(address) };
 
   const queryKey: QueryRawKey = ["USE_QUERY_RAW", address, key] as const;
   const query = useQuery(queryKey, ({ queryKey: [, _address] }) => getQueryRaw(address, key), options);

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -120,6 +120,22 @@ export type UseInstantiateContractArgs<Message extends Record<string, unknown>> 
   codeId: number;
 } & MutationEventArgs<InstantiateContractMutationArgs<Message>, InstantiateResult>;
 
+/**
+ * graz mutation hook to instantiate a CosmWasm smart contract when supported.
+ *
+ * @example
+ * ```ts
+ * import { useInstantiateContract } from "graz"
+ *
+ * const { instantiateContract: instantiateMyContract } = useInstantiateContract({
+ *   codeId: 4,
+ *   onSuccess: ({ contractAddress }) => console.log('Address:', contractAddress)
+ * })
+ *
+ * const instantiateMessage = { foo: 'bar' };
+ * instantiateMyContract(instantiateMessage);
+ * ```
+ */
 export const useInstantiateContract = <Message extends Record<string, unknown>>({
   codeId,
   onError,
@@ -161,6 +177,29 @@ export type UseExecuteContractArgs<Message extends Record<string, unknown>> = {
   contractAddress: string;
 } & MutationEventArgs<ExecuteContractMutationArgs<Message>, ExecuteResult>;
 
+/**
+ * graz mutation hook for executing transactions against a CosmWasm smart
+ * contract.
+ *
+ * @example
+ * ```ts
+ * import { useInstantiateContract } from "graz"
+ *
+ * interface GreetMessage {
+ *   name: string;
+ * }
+ *
+ * interface GreetResponse {
+ *   message: string;
+ * }
+ *
+ * const contractAddress = "cosmosfoobarbaz";
+ * const { executeContract } = useExecuteContract<ExecuteMessage>({ contractAddress });
+ * executeContract({ name: 'CosmWasm' }, {
+ *   onSuccess: (data: GreetResponse) => console.log('Got message:', data.message);
+ * });
+ * ```
+ */
 export const useExecuteContract = <Message extends Record<string, unknown>>({
   contractAddress,
   onError,
@@ -207,6 +246,20 @@ export type QueryOptions<TQueryFnData, TError, TData, TQueryKey extends QueryKey
 
 export type QuerySmartKey = readonly ["USE_QUERY_SMART", string | undefined, Record<string, unknown> | undefined];
 
+/**
+ * graz query hook for dispatching a "smart" query to a CosmWasm smart
+ * contract.
+ *
+ * Note: In order to make the hook more flexible, address and queryMsg are
+ * optional, but the query will be automatically disabled if either of them are
+ * not present. This makes it possible to register the hook before the address
+ * or queryMsg are known.
+ *
+ * @param address - The address of the contract to query
+ * @param queryMsg - The query message to send to the contract
+ * @param options - Optional react-query QueryOptions
+ * @returns A query result with the result returned by the smart contract.
+ */
 export const useQuerySmart = <TQueryFnData, TError, TData>(
   address?: string,
   queryMsg?: Record<string, unknown>,
@@ -224,6 +277,18 @@ export const useQuerySmart = <TQueryFnData, TError, TData>(
 
 export type QueryRawKey = readonly ["USE_QUERY_RAW", string, string | undefined];
 
+/**
+ * graz query hook for dispatching a "raw" query to a CosmWasm smart contract.
+ *
+ * Note: In order to make the hook more flexible, address is optional, but
+ * the query will be automatically disabled if either of them are not present.
+ * This makes it possible to register the hook before the address is known.
+ *
+ * @param key - The key to lookup in the contract storage
+ * @param address - The address of the contract to query
+ * @param options - Optional react-query QueryOptions
+ * @returns A query result with raw byte array stored at the key queried.
+ */
 export const useQueryRaw = <TError>(
   key: string,
   address?: string,

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -160,7 +160,7 @@ export const useInstantiateContract = <Message extends Record<string, unknown>>(
   const mutation = useMutation(queryKey, mutationFn, {
     onError: (err, data) => Promise.resolve(onError?.(err, data)),
     onMutate: onLoading,
-    onSuccess: (txResponse) => Promise.resolve(onSuccess?.(txResponse)),
+    onSuccess: (instantiateResult) => Promise.resolve(onSuccess?.(instantiateResult)),
   });
 
   return {
@@ -224,7 +224,7 @@ export const useExecuteContract = <Message extends Record<string, unknown>>({
   const mutation = useMutation(queryKey, mutationFn, {
     onError: (err, data) => Promise.resolve(onError?.(err, data)),
     onMutate: onLoading,
-    onSuccess: (txResponse) => Promise.resolve(onSuccess?.(txResponse)),
+    onSuccess: (executeResult) => Promise.resolve(onSuccess?.(executeResult)),
   });
 
   return {

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -146,6 +146,7 @@ export const useInstantiateContract = <Message extends Record<string, unknown>>(
   const accountAddress = account?.bech32Address;
 
   const mutationFn = (args: InstantiateContractMutationArgs<Message>) => {
+    if (!accountAddress) throw new Error("senderAddress is undefined");
     const contractArgs: InstantiateContractArgs<Message> = {
       ...args,
       fee: args.fee ?? "auto",
@@ -210,6 +211,7 @@ export const useExecuteContract = <Message extends Record<string, unknown>>({
   const accountAddress = account?.bech32Address;
 
   const mutationFn = (args: ExecuteContractMutationArgs<Message>) => {
+    if (!accountAddress) throw new Error("senderAddress is undefined");
     const executeArgs: ExecuteContractArgs<Message> = {
       ...args,
       fee: args.fee ?? "auto",

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -243,11 +243,6 @@ export const useExecuteContract = <Message extends Record<string, unknown>>({
  * graz query hook for dispatching a "smart" query to a CosmWasm smart
  * contract.
  *
- * Note: In order to make the hook more flexible, address and queryMsg are
- * optional, but the query will be automatically disabled if either of them are
- * not present. This makes it possible to register the hook before the address
- * or queryMsg are known.
- *
  * @param address - The address of the contract to query
  * @param queryMsg - The query message to send to the contract
  * @returns A query result with the result returned by the smart contract.
@@ -273,10 +268,6 @@ export const useQuerySmart = <TData, TError>(
 
 /**
  * graz query hook for dispatching a "raw" query to a CosmWasm smart contract.
- *
- * Note: In order to make the hook more flexible, address and key are optional, but
- * the query will be automatically disabled if either of them are not present.
- * This makes it possible to register the hook before the address or key are known.
  *
  * @param address - The address of the contract to query
  * @param key - The key to lookup in the contract storage

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -1,8 +1,14 @@
+import type { InstantiateResult } from "@cosmjs/cosmwasm-stargate";
 import type { DeliverTxResponse } from "@cosmjs/stargate";
 import { useMutation } from "@tanstack/react-query";
 
-import type { SendIbcTokensArgs, SendTokensArgs } from "../actions/methods";
-import { sendIbcTokens, sendTokens } from "../actions/methods";
+import type {
+  InstantiateContractArgs,
+  InstantiateContractMutationArgs,
+  SendIbcTokensArgs,
+  SendTokensArgs,
+} from "../actions/methods";
+import { instantiateContract, sendIbcTokens, sendTokens } from "../actions/methods";
 import type { MutationEventArgs } from "../types/hooks";
 import { useAccount } from "./account";
 
@@ -96,6 +102,47 @@ export const useSendIbcTokens = ({
     isSuccess: mutation.isSuccess,
     sendIbcTokens: mutation.mutate,
     sendIbcTokensAsync: mutation.mutateAsync,
+    status: mutation.status,
+  };
+};
+
+export type UseInstantiateContractArgs<Message extends Record<string, unknown>> = {
+  codeId: number;
+} & MutationEventArgs<InstantiateContractMutationArgs<Message>, InstantiateResult>;
+
+export const useInstantiateContract = <Message extends Record<string, unknown>>({
+  codeId,
+  onError,
+  onLoading,
+  onSuccess,
+}: UseInstantiateContractArgs<Message>) => {
+  const { data: account } = useAccount();
+  const accountAddress = account?.bech32Address;
+
+  const mutationFn = (args: InstantiateContractMutationArgs<Message>) => {
+    const contractArgs: InstantiateContractArgs<Message> = {
+      ...args,
+      fee: args.fee ?? "auto",
+      senderAddress: accountAddress,
+      codeId,
+    };
+
+    return instantiateContract(contractArgs);
+  };
+
+  const queryKey = ["USE_INSTANTIATE_CONTRACT", onError, onLoading, onSuccess, codeId];
+  const mutation = useMutation(queryKey, mutationFn, {
+    onError: (err, data) => Promise.resolve(onError?.(err, data)),
+    onMutate: onLoading,
+    onSuccess: (txResponse) => Promise.resolve(onSuccess?.(txResponse)),
+  });
+
+  return {
+    error: mutation.error,
+    isLoading: mutation.isLoading,
+    isSuccess: mutation.isSuccess,
+    instantiateContract: mutation.mutate,
+    instantiateContractAsync: mutation.mutateAsync,
     status: mutation.status,
   };
 };

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -183,7 +183,7 @@ export type UseExecuteContractArgs<Message extends Record<string, unknown>> = {
  *
  * @example
  * ```ts
- * import { useInstantiateContract } from "graz"
+ * import { useExecuteContract } from "graz"
  *
  * interface GreetMessage {
  *   name: string;

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -274,9 +274,9 @@ export const useQuerySmart = <TData, TError>(
 /**
  * graz query hook for dispatching a "raw" query to a CosmWasm smart contract.
  *
- * Note: In order to make the hook more flexible, address is optional, but
+ * Note: In order to make the hook more flexible, address and key are optional, but
  * the query will be automatically disabled if either of them are not present.
- * This makes it possible to register the hook before the address is known.
+ * This makes it possible to register the hook before the address or key are known.
  *
  * @param address - The address of the contract to query
  * @param key - The key to lookup in the contract storage

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -222,17 +222,19 @@ export const useQuerySmart = <TQueryFnData, TError, TData>(
   return query;
 };
 
-export type QueryRawKey = readonly ["USE_QUERY_RAW", string, Uint8Array];
+export type QueryRawKey = readonly ["USE_QUERY_RAW", string, string | undefined];
 
-export const useQueryRaw = <TQueryFnData, TError, TData>(
-  address: string,
-  key: Uint8Array,
-  options?: QueryOptions<TQueryFnData, TError, TData, QueryRawKey>,
-): UseQueryResult<TData, TError> => {
-  const queryOptions: QueryOptions<TQueryFnData, TError, TData, QueryRawKey> = options || { enabled: Boolean(address) };
+export const useQueryRaw = <TError>(
+  key: string,
+  address?: string,
+  options?: QueryOptions<Uint8Array | null, TError, Uint8Array | null, QueryRawKey>,
+): UseQueryResult<Uint8Array | null, TError> => {
+  const enabled = Boolean(address);
+  const queryOptions: QueryOptions<Uint8Array | null, TError, Uint8Array | null, QueryRawKey> =
+    options !== undefined ? { ...options, enabled: Boolean(options.enabled) && enabled } : { enabled };
 
-  const queryKey: QueryRawKey = ["USE_QUERY_RAW", address, key] as const;
-  const query = useQuery(queryKey, ({ queryKey: [, _address] }) => getQueryRaw(address, key), options);
+  const queryKey: QueryRawKey = ["USE_QUERY_RAW", key, address] as const;
+  const query = useQuery(queryKey, ({ queryKey: [, _address] }) => getQueryRaw(key, address), queryOptions);
 
   return query;
 };

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -205,19 +205,19 @@ export type QueryOptions<TQueryFnData, TError, TData, TQueryKey extends QueryKey
   initialData?: () => undefined;
 };
 
-export type QuerySmartKey = readonly ["USE_QUERY_SMART", string, Record<string, unknown>];
+export type QuerySmartKey = readonly ["USE_QUERY_SMART", string | undefined, Record<string, unknown> | undefined];
 
 export const useQuerySmart = <TQueryFnData, TError, TData>(
-  address: string,
-  queryMsg: Record<string, unknown>,
+  address?: string,
+  queryMsg?: Record<string, unknown>,
   options?: QueryOptions<TQueryFnData, TError, TData, QuerySmartKey>,
 ): UseQueryResult<TData, TError> => {
-  const queryOptions: QueryOptions<TQueryFnData, TError, TData, QuerySmartKey> = options || {
-    enabled: Boolean(address),
-  };
+  const argsPresent = Boolean(address) && Boolean(queryMsg);
+  const queryOptions: QueryOptions<TQueryFnData, TError, TData, QuerySmartKey> =
+    options !== undefined ? { ...options, enabled: Boolean(options.enabled) && argsPresent } : { enabled: argsPresent };
 
   const queryKey: QuerySmartKey = ["USE_QUERY_SMART", address, queryMsg] as const;
-  const query = useQuery(queryKey, ({ queryKey: [, _address] }) => getQuerySmart(address, queryMsg), options);
+  const query = useQuery(queryKey, ({ queryKey: [, _address] }) => getQuerySmart(address, queryMsg), queryOptions);
 
   return query;
 };

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -156,7 +156,7 @@ export const useInstantiateContract = <Message extends Record<string, unknown>>(
     return instantiateContract(contractArgs);
   };
 
-  const queryKey = ["USE_INSTANTIATE_CONTRACT", onError, onLoading, onSuccess, codeId];
+  const queryKey = ["USE_INSTANTIATE_CONTRACT", onError, onLoading, onSuccess, codeId, accountAddress];
   const mutation = useMutation(queryKey, mutationFn, {
     onError: (err, data) => Promise.resolve(onError?.(err, data)),
     onMutate: onLoading,
@@ -220,7 +220,7 @@ export const useExecuteContract = <Message extends Record<string, unknown>>({
     return executeContract(executeArgs);
   };
 
-  const queryKey = ["USE_EXECUTE_CONTRACT", onError, onLoading, onSuccess, contractAddress];
+  const queryKey = ["USE_EXECUTE_CONTRACT", onError, onLoading, onSuccess, contractAddress, accountAddress];
   const mutation = useMutation(queryKey, mutationFn, {
     onError: (err, data) => Promise.resolve(onError?.(err, data)),
     onMutate: onLoading,


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This closes feature request #50.

First, want to highlight that the primary author of this change is @BurntVal and that my role has merely been to review, give advice, and liaise!

This PR introduces four hooks for interacting with CosmWasm smart contracts in React applications. They are:

- `useInstantiateContract`—a mutator to instantiate a smart contract with a message provided by the caller.
- `useExecuteContract`—a mutator to execute a smart contract, passing it a message provided by the caller.
- `useQueryRaw` and `useQuerySmart`—Hooks to query the state stored within a smart contract.

We made our best effort to follow the style and standards of the graz codebase. We generally made an effort to keep the typing as strong as possible, so the mutators are all parameterized by input and output types.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

- [x] Added `useInstantiateContract` hook
- [x] Added `useExecuteContract` hook
- [x] Added `useQuerySmart` hook
- [x] Added `useQueryRaw` hook

## Screenshots

n/a

## Testing

To test our changes, we locally extended the sample project in `templates/default` to include queries and transactions made to various sample contracts using all of the hooks added in this change request. Through testing in this application setting, we confirmed instantiation, execution, smart queries, and raw queries all worked.

## Links/References

- [CosmWasm](https://docs.cosmwasm.com/docs/1.0/)
- [@cosmjs/cosmwasm-stargate](https://cosmos.github.io/cosmjs/latest/cosmwasm-stargate/index.html)

## Notes

- In order to make the hooks flexible, many of the hook arguments are optional (in the event that they are not yet known at first component render). In these instances (in the queries, specifically), the hooks will be automatically disabled until they are present to avoid invalid queries.