### PR TITLE
Fix/contract executions refactor

### DIFF
--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -139,14 +139,16 @@ export interface ExecuteContractArgs<Message extends Record<string, unknown>> {
   senderAddress: string;
   contractAddress: string;
   funds: Coin[];
-  memo: string | undefined;
+  memo: string;
 }
 
 export type ExecuteContractMutationArgs<Message extends Record<string, unknown>> = Omit<
   ExecuteContractArgs<Message>,
-  "contractAddress" | "senderAddress" | "fee"
+  "contractAddress" | "senderAddress" | "fee" | "funds" | "memo"
 > & {
   fee?: StdFee | "auto" | number;
+  funds?: Coin[];
+  memo?: string;
 };
 
 export const executeContract = async <Message extends Record<string, unknown>>({

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -139,6 +139,7 @@ export interface ExecuteContractArgs<Message extends Record<string, unknown>> {
   senderAddress: string;
   contractAddress: string;
   funds: Coin[];
+  memo: string | undefined;
 }
 
 export type ExecuteContractMutationArgs<Message extends Record<string, unknown>> = Omit<
@@ -154,6 +155,7 @@ export const executeContract = async <Message extends Record<string, unknown>>({
   fee,
   contractAddress,
   funds,
+  memo,
 }: ExecuteContractArgs<Message>) => {
   const { signingClients } = useGrazStore.getState();
 
@@ -161,7 +163,7 @@ export const executeContract = async <Message extends Record<string, unknown>>({
     throw new Error("CosmWasm signing client is not ready");
   }
 
-  return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee, funds);
+  return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee, memo, funds);
 };
 
 export const getQuerySmart = async <TData>(address: string, queryMsg: Record<string, unknown>): Promise<TData> => {

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -138,6 +138,7 @@ export interface ExecuteContractArgs<Message extends Record<string, unknown>> {
   fee: StdFee | "auto" | number;
   senderAddress: string;
   contractAddress: string;
+  funds: Coin[];
 }
 
 export type ExecuteContractMutationArgs<Message extends Record<string, unknown>> = Omit<
@@ -152,6 +153,7 @@ export const executeContract = async <Message extends Record<string, unknown>>({
   msg,
   fee,
   contractAddress,
+  funds,
 }: ExecuteContractArgs<Message>) => {
   const { signingClients } = useGrazStore.getState();
 
@@ -159,7 +161,7 @@ export const executeContract = async <Message extends Record<string, unknown>>({
     throw new Error("CosmWasm signing client is not ready");
   }
 
-  return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee);
+  return signingClients.cosmWasm.execute(senderAddress, contractAddress, msg, fee, funds);
 };
 
 export const getQuerySmart = async <TData>(address: string, queryMsg: Record<string, unknown>): Promise<TData> => {

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -222,7 +222,7 @@ export const useExecuteContract = <Message extends Record<string, unknown>>({
       fee: args.fee ?? "auto",
       senderAddress: accountAddress,
       contractAddress,
-      funds: args.funds ?? [],
+      funds: args.funds || [],
     };
 
     return executeContract(executeArgs);

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -222,6 +222,7 @@ export const useExecuteContract = <Message extends Record<string, unknown>>({
       fee: args.fee ?? "auto",
       senderAddress: accountAddress,
       contractAddress,
+      funds: args.funds ?? [],
     };
 
     return executeContract(executeArgs);

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -222,7 +222,8 @@ export const useExecuteContract = <Message extends Record<string, unknown>>({
       fee: args.fee ?? "auto",
       senderAddress: accountAddress,
       contractAddress,
-      funds: args.funds || [],
+      memo: args.memo ?? "",
+      funds: args.funds ?? [],
     };
 
     return executeContract(executeArgs);


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR aims to fix an oversight in our initial PR, where we implemented smart contracts hooks (namely useExecuteContract). We didn't pass the funds and memo params to the execute call, leading to errors in production case where those params are needed.

## Checklist

- [X] I have made sure the upstream branch for this PR is correct
- [X] I have made sure this PR is ready to merge
- [X] I have made sure that I have assigned reviewers related to this project

## Changes

- [X] Added fields to ExecuteContractArgs & ExecuteContractMutationArgs interface, and passed appropriately to execute call
- [ ] Changed ...
- [ ] Removed ...

## Testing

Create an execute msg for the returned executeContract function from the useExecuteContract hook, now with the ability to add "funds" and "memo" fields
