### PR TITLE
Use standard clients for queries

### DIFF
--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -169,23 +169,23 @@ export const executeContract = async <Message extends Record<string, unknown>>({
 };
 
 export const getQuerySmart = async <TData>(address: string, queryMsg: Record<string, unknown>): Promise<TData> => {
-  const { signingClients } = useGrazStore.getState();
+  const { clients } = useGrazStore.getState();
 
-  if (!signingClients?.cosmWasm) {
-    throw new Error("CosmWasm signing client is not ready");
+  if (!clients?.cosmWasm) {
+    throw new Error("CosmWasm client is not ready");
   }
 
-  const result = (await signingClients.cosmWasm.queryContractSmart(address, queryMsg)) as TData;
+  const result = (await clients.cosmWasm.queryContractSmart(address, queryMsg)) as TData;
   return result;
 };
 
 export const getQueryRaw = (address: string, keyStr: string): Promise<Uint8Array | null> => {
-  const { signingClients } = useGrazStore.getState();
+  const { clients } = useGrazStore.getState();
 
-  if (!signingClients?.cosmWasm) {
-    throw new Error("CosmWasm signing client is not ready");
+  if (!clients?.cosmWasm) {
+    throw new Error("CosmWasm client is not ready");
   }
 
   const key = new TextEncoder().encode(keyStr);
-  return signingClients.cosmWasm.queryContractRaw(address, key);
+  return clients.cosmWasm.queryContractRaw(address, key);
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR relaxes the smart contract query hooks requirements from a signing CosmWasm client to a standard CosmWasm client. This makes it possible to use the hooks when an application has not connected a wallet or otherwise created a signing client.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

- [x] Changed destructuring of the graz store to pull out the standard clients object rather than the signing clients object and subsequently use it to execute CosmWasm queries when a CosmWasm client is present.

## Testing

- Create a sample application that instantiates clients via `useClients`
- Query a smart contract on the target chain with one of the useQuerySmart or useQueryRaw hooks
- Verify that a result was returned without need for a signing client.

