### PR TITLE
Cache clients created from a call to useClients

### DIFF
--- a/packages/graz/src/hooks/clients.ts
+++ b/packages/graz/src/hooks/clients.ts
@@ -34,6 +34,9 @@ export const useClients = (args?: CreateClientArgs): UseQueryResult<GrazStore["c
     {
       refetchOnMount: false,
       refetchOnWindowFocus: false,
+      onSuccess: (clients) => {
+        useGrazStore.setState({ clients });
+      },
     },
   );
 


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

When a programmer passes CreateClientArgs to useClients, graz will create a client for the given chain, but will not cache it in the graz store, leading to strange issues where a client has been connected but cannot be retrieved via useClients calls with no arguments. This change stores the clients in the zustand store to avoid such issues.

## Checklist

- [ ] I have made sure the upstream branch for this PR is correct
- [ ] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

## Changes

- [ ] Added an onSuccess callback to the query in useClients that updates the zustand store with the newly created clients

## Testing

To test this, I modified the `example` app to do the following:
- Use a `useClients` call with chain info passed to it to create a client for a locally running chain **without having to connect a wallet**
- Make a call with useQuerySmart to query a contract on that chain
- Add logs to show that the query does not dispatch until the client is made, at which time it is successfully dispatched
