### PR TITLE
Feat(store)  split session and local storage

### DIFF
--- a/example/pages/_app.tsx
+++ b/example/pages/_app.tsx
@@ -16,6 +16,7 @@ const CustomApp: NextPage<AppProps> = ({ Component, pageProps }) => {
           },
           autoReconnect: false,
         }}
+        debug
       >
         <Component {...pageProps} />
       </GrazProvider>

--- a/packages/graz/package.json
+++ b/packages/graz/package.json
@@ -38,6 +38,7 @@
     "@keplr-wallet/cosmos": "^0.11.64",
     "@keplr-wallet/types": "^0.11.64",
     "@tanstack/react-query": "^4.29.11",
+    "@tanstack/react-query-devtools": "^4.29.12",
     "@walletconnect/sign-client": "^2.7.7",
     "@walletconnect/types": "^2.7.7",
     "@walletconnect/utils": "^2.7.7",

--- a/packages/graz/src/actions/chains.ts
+++ b/packages/graz/src/actions/chains.ts
@@ -2,7 +2,7 @@ import type { SigningCosmWasmClientOptions } from "@cosmjs/cosmwasm-stargate";
 import type { AppCurrency, ChainInfo } from "@keplr-wallet/types";
 
 import type { GrazChain } from "../chains";
-import { useGrazStore } from "../store";
+import { useGrazInternalStore, useGrazSessionStore } from "../store";
 import type { Dictionary } from "../types/core";
 import type { WalletType } from "../types/wallet";
 import type { ConnectResult } from "./account";
@@ -12,16 +12,16 @@ import { getWallet } from "./wallet";
 export * from "./clients/tendermint";
 
 export const clearRecentChain = (): void => {
-  useGrazStore.setState({ recentChain: null });
+  useGrazInternalStore.setState({ recentChain: null });
 };
 
 export const getActiveChainCurrency = (denom: string): AppCurrency | undefined => {
-  const { activeChain } = useGrazStore.getState();
+  const { activeChain } = useGrazSessionStore.getState();
   return activeChain?.currencies.find((x) => x.coinMinimalDenom === denom);
 };
 
 export const getRecentChain = (): GrazChain | null => {
-  return useGrazStore.getState().recentChain;
+  return useGrazInternalStore.getState().recentChain;
 };
 
 export const suggestChain = async (chainInfo: ChainInfo): Promise<ChainInfo> => {

--- a/packages/graz/src/actions/clients.ts
+++ b/packages/graz/src/actions/clients.ts
@@ -6,13 +6,13 @@ import { SigningStargateClient } from "@cosmjs/stargate";
 import { Tendermint34Client } from "@cosmjs/tendermint-rpc";
 
 import type { GrazChain } from "../chains";
-import type { GrazStore } from "../store";
+import type { GrazSessionStore } from "../store";
 
 export * from "./clients/tendermint";
 
 export type CreateClientArgs = Pick<GrazChain, "rpc" | "rpcHeaders">;
 
-export const createClients = async ({ rpc, rpcHeaders }: CreateClientArgs): Promise<GrazStore["clients"]> => {
+export const createClients = async ({ rpc, rpcHeaders }: CreateClientArgs): Promise<GrazSessionStore["clients"]> => {
   const endpoint: HttpEndpoint = { url: rpc, headers: { ...(rpcHeaders || {}) } };
   const [cosmWasm, stargate, tendermint] = await Promise.all([
     SigningCosmWasmClient.connect(endpoint),
@@ -28,7 +28,9 @@ export type CreateSigningClientArgs = CreateClientArgs & {
   stargateSignerOptions?: SigningStargateClientOptions;
 };
 
-export const createSigningClients = async (args: CreateSigningClientArgs): Promise<GrazStore["signingClients"]> => {
+export const createSigningClients = async (
+  args: CreateSigningClientArgs,
+): Promise<GrazSessionStore["signingClients"]> => {
   const { rpc, rpcHeaders, offlineSignerAuto, cosmWasmSignerOptions = {}, stargateSignerOptions = {} } = args;
   const endpoint: HttpEndpoint = { url: rpc, headers: { ...(rpcHeaders || {}) } };
   const [cosmWasm, stargate] = await Promise.all([

--- a/packages/graz/src/actions/clients/tendermint.ts
+++ b/packages/graz/src/actions/clients/tendermint.ts
@@ -3,7 +3,7 @@
 import { QueryClient } from "@cosmjs/stargate";
 import { assert, isNonNullObject } from "@cosmjs/utils";
 
-import { useGrazStore } from "../../store";
+import { useGrazSessionStore } from "../../store";
 import type { ExtensionSetup } from "../../types/tendermint";
 
 // https://stackoverflow.com/a/53143568/4273667
@@ -101,7 +101,7 @@ export interface CreateQueryClient {
  * NOT to be confused with \@tanstack/react-query query client
  */
 export const createQueryClient: CreateQueryClient = (...extensionSetups: ExtensionSetup[]) => {
-  const { tendermint } = useGrazStore.getState().clients!;
+  const { tendermint } = useGrazSessionStore.getState().clients!;
   const queryClient = new QueryClient(tendermint);
   const exts = extensionSetups.map((setup) => setup(queryClient));
   for (const ext of exts) {

--- a/packages/graz/src/actions/configure.ts
+++ b/packages/graz/src/actions/configure.ts
@@ -1,15 +1,15 @@
 import type { GrazChain } from "../chains";
-import type { GrazStore } from "../store";
-import { useGrazStore } from "../store";
+import type { GrazInternalStore } from "../store";
+import { useGrazInternalStore } from "../store";
 import type { WalletType } from "../types/wallet";
 
 export interface ConfigureGrazArgs {
   defaultChain?: GrazChain;
-  defaultSigningClient?: GrazStore["defaultSigningClient"];
+  defaultSigningClient?: GrazInternalStore["defaultSigningClient"];
   defaultWallet?: WalletType;
   onNotFound?: () => void;
   onReconnectFailed?: () => void;
-  walletConnect?: GrazStore["walletConnect"];
+  walletConnect?: GrazInternalStore["walletConnect"];
   /**
    * default to true
    */
@@ -17,7 +17,7 @@ export interface ConfigureGrazArgs {
 }
 
 export const configureGraz = (args: ConfigureGrazArgs = {}): ConfigureGrazArgs => {
-  useGrazStore.setState((prev) => ({
+  useGrazInternalStore.setState((prev) => ({
     defaultChain: args.defaultChain || prev.defaultChain,
     defaultSigningClient: args.defaultSigningClient || prev.defaultSigningClient,
     walletConnect: args.walletConnect || prev.walletConnect,

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -3,16 +3,16 @@ import type { Coin } from "@cosmjs/proto-signing";
 import type { DeliverTxResponse, StdFee } from "@cosmjs/stargate";
 import type { Height } from "cosmjs-types/ibc/core/client/v1/client";
 
-import { useGrazStore } from "../store";
+import { useGrazInternalStore, useGrazSessionStore } from "../store";
 
 export const getBalances = async (bech32Address: string): Promise<Coin[]> => {
-  const { activeChain, signingClients } = useGrazStore.getState();
+  const { activeChain, signingClients } = useGrazSessionStore.getState();
 
   if (!activeChain || !signingClients) {
     throw new Error("No connected account detected");
   }
 
-  const { defaultSigningClient } = useGrazStore.getState();
+  const { defaultSigningClient } = useGrazInternalStore.getState();
   const balances = await Promise.all(
     activeChain.currencies.map(async (item) => {
       const isCw20 = item.coinMinimalDenom.startsWith("cw20:");
@@ -27,7 +27,7 @@ export const getBalances = async (bech32Address: string): Promise<Coin[]> => {
 };
 
 export const getBalanceStaked = async (bech32Address: string): Promise<Coin | null> => {
-  const { clients } = useGrazStore.getState();
+  const { clients } = useGrazSessionStore.getState();
   if (!clients?.stargate) {
     throw new Error("Stargate client is not ready");
   }
@@ -50,7 +50,8 @@ export const sendTokens = async ({
   fee,
   memo,
 }: SendTokensArgs): Promise<DeliverTxResponse> => {
-  const { signingClients, defaultSigningClient } = useGrazStore.getState();
+  const { defaultSigningClient } = useGrazInternalStore.getState();
+  const { signingClients } = useGrazSessionStore.getState();
   if (!signingClients) {
     throw new Error("No connected account detected");
   }
@@ -84,7 +85,7 @@ export const sendIbcTokens = async ({
   fee,
   memo,
 }: SendIbcTokensArgs) => {
-  const { signingClients } = useGrazStore.getState();
+  const { signingClients } = useGrazSessionStore.getState();
   if (!signingClients?.stargate) {
     throw new Error("Stargate signing client is not ready");
   }
@@ -128,7 +129,7 @@ export const instantiateContract = async <Message extends Record<string, unknown
   label,
   codeId,
 }: InstantiateContractArgs<Message>) => {
-  const { signingClients } = useGrazStore.getState();
+  const { signingClients } = useGrazSessionStore.getState();
 
   if (!signingClients?.cosmWasm) {
     throw new Error("CosmWasm signing client is not ready");
@@ -163,7 +164,7 @@ export const executeContract = async <Message extends Record<string, unknown>>({
   funds,
   memo,
 }: ExecuteContractArgs<Message>) => {
-  const { signingClients } = useGrazStore.getState();
+  const { signingClients } = useGrazSessionStore.getState();
 
   if (!signingClients?.cosmWasm) {
     throw new Error("CosmWasm signing client is not ready");
@@ -173,7 +174,7 @@ export const executeContract = async <Message extends Record<string, unknown>>({
 };
 
 export const getQuerySmart = async <TData>(address: string, queryMsg: Record<string, unknown>): Promise<TData> => {
-  const { clients } = useGrazStore.getState();
+  const { clients } = useGrazSessionStore.getState();
 
   if (!clients?.cosmWasm) {
     throw new Error("CosmWasm client is not ready");
@@ -184,7 +185,7 @@ export const getQuerySmart = async <TData>(address: string, queryMsg: Record<str
 };
 
 export const getQueryRaw = (address: string, keyStr: string): Promise<Uint8Array | null> => {
-  const { clients } = useGrazStore.getState();
+  const { clients } = useGrazSessionStore.getState();
 
   if (!clients?.cosmWasm) {
     throw new Error("CosmWasm client is not ready");

--- a/packages/graz/src/hooks/chains.ts
+++ b/packages/graz/src/hooks/chains.ts
@@ -9,7 +9,7 @@ import type { ConnectResult } from "../actions/account";
 import type { SuggestChainAndConnectArgs } from "../actions/chains";
 import { clearRecentChain, getActiveChainCurrency, suggestChain, suggestChainAndConnect } from "../actions/chains";
 import type { GrazChain } from "../chains";
-import { useGrazStore } from "../store";
+import { useGrazInternalStore, useGrazSessionStore } from "../store";
 import type { MutationEventArgs } from "../types/hooks";
 import { useCheckWallet } from "./wallet";
 
@@ -23,7 +23,7 @@ import { useCheckWallet } from "./wallet";
  * ```
  */
 export const useActiveChain = (): GrazChain | null => {
-  return useGrazStore((x) => x.activeChain);
+  return useGrazSessionStore((x) => x.activeChain);
 };
 
 /**
@@ -92,7 +92,7 @@ export const useActiveChainValidators = <T extends QueryClient & StakingExtensio
  * @see {@link useActiveChain}
  */
 export const useRecentChain = () => {
-  const recentChain = useGrazStore((x) => x.recentChain);
+  const recentChain = useGrazInternalStore((x) => x.recentChain);
   return { data: recentChain, clear: clearRecentChain };
 };
 

--- a/packages/graz/src/hooks/clients.ts
+++ b/packages/graz/src/hooks/clients.ts
@@ -2,11 +2,10 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 
 import type { CreateClientArgs, CreateSigningClientArgs } from "../actions/clients";
-import { createClients, createSigningClients } from "../actions/clients";
-import type { GrazStore } from "../store";
-import { useGrazStore } from "../store";
-
-export * from "./clients/tendermint";
+import { createSigningClients } from "../actions/clients";
+import { createClients } from "../actions/clients";
+import type { GrazSessionStore } from "../store";
+import { useGrazSessionStore } from "../store";
 
 /**
  * graz query hook to retrieve a CosmWasmClient, StargateClient and Tendermint34Client. If there's no given arguments it will be using the current connected client
@@ -22,8 +21,8 @@ export * from "./clients/tendermint";
  * useClient({ rpc: "https://rpc.cosmoshub.strange.love", });
  * ```
  */
-export const useClients = (args?: CreateClientArgs): UseQueryResult<GrazStore["clients"]> => {
-  const currentClient = useGrazStore((x) => x.clients);
+export const useClients = (args?: CreateClientArgs): UseQueryResult<GrazSessionStore["clients"]> => {
+  const currentClient = useGrazSessionStore((x) => x.clients);
 
   const queryKey = ["USE_CLIENTS", args, currentClient] as const;
   const query = useQuery(
@@ -35,8 +34,9 @@ export const useClients = (args?: CreateClientArgs): UseQueryResult<GrazStore["c
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       onSuccess: (clients) => {
-        useGrazStore.setState({ clients });
+        useGrazSessionStore.setState({ clients });
       },
+      initialData: currentClient,
     },
   );
 
@@ -61,10 +61,12 @@ export const useClients = (args?: CreateClientArgs): UseQueryResult<GrazStore["c
  * });
  * ```
  */
-export const useSigningClients = (args?: CreateSigningClientArgs): UseQueryResult<GrazStore["signingClients"]> => {
-  const currentClient = useGrazStore((x) => x.signingClients);
+export const useSigningClients = (
+  args?: CreateSigningClientArgs,
+): UseQueryResult<GrazSessionStore["signingClients"]> => {
+  const currentSigningClient = useGrazSessionStore((x) => x.signingClients);
 
-  const queryKey = ["USE_SIGNING_CLIENTS", args, currentClient] as const;
+  const queryKey = ["USE_SIGNING_CLIENTS", args, currentSigningClient] as const;
   const query = useQuery(
     queryKey,
     ({ queryKey: [, _args, _current] }) => {
@@ -74,8 +76,9 @@ export const useSigningClients = (args?: CreateSigningClientArgs): UseQueryResul
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       onSuccess: (signingClients) => {
-        useGrazStore.setState({ signingClients });
+        useGrazSessionStore.setState({ signingClients });
       },
+      initialData: currentSigningClient,
     },
   );
 

--- a/packages/graz/src/hooks/wallet.ts
+++ b/packages/graz/src/hooks/wallet.ts
@@ -2,7 +2,7 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 
 import { checkWallet } from "../actions/wallet";
-import { useGrazStore } from "../store";
+import { useGrazInternalStore } from "../store";
 import type { WalletType } from "../types/wallet";
 
 /**
@@ -17,7 +17,7 @@ import type { WalletType } from "../types/wallet";
  * ```
  */
 export const useCheckWallet = (type?: WalletType): UseQueryResult<boolean> => {
-  const walletType = useGrazStore((x) => type || x.walletType);
+  const walletType = useGrazInternalStore((x) => type || x.walletType);
 
   const queryKey = ["USE_CHECK_WALLET", walletType] as const;
   const query = useQuery(queryKey, ({ queryKey: [, _type] }) => checkWallet(_type));

--- a/packages/graz/src/index.ts
+++ b/packages/graz/src/index.ts
@@ -9,6 +9,7 @@ export * from "./chains";
 export * from "./hooks/account";
 export * from "./hooks/chains";
 export * from "./hooks/clients";
+export * from "./hooks/clients/tendermint";
 export * from "./hooks/methods";
 export * from "./hooks/wallet";
 export * from "./provider";

--- a/packages/graz/src/provider/client-only.tsx
+++ b/packages/graz/src/provider/client-only.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+export const ClientOnly = ({ children }: { children: ReactNode }) => {
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  return <>{isHydrated ? children : null}</>;
+};

--- a/packages/graz/src/provider/events.tsx
+++ b/packages/graz/src/provider/events.tsx
@@ -3,18 +3,19 @@ import { useEffect } from "react";
 
 import { reconnect } from "../actions/account";
 import { RECONNECT_SESSION_KEY } from "../constant";
-import { useGrazStore } from "../store";
+import { useGrazInternalStore, useGrazSessionStore } from "../store";
 import { WalletType } from "../types/wallet";
 
 /**
- * Graz custom hook to track `keplr_keystorechange` event and reconnect state
+ * Graz custom hook to track `keplr_keystorechange`, `leap_keystorechange`, `accountChanged` event and reconnect state
  *
  * **Note: only use this hook if not using graz's provider component.**
  */
 export const useGrazEvents = () => {
   const isSessionActive =
     typeof window !== "undefined" && window.sessionStorage.getItem(RECONNECT_SESSION_KEY) === "Active";
-  const { activeChain, _reconnect, _onReconnectFailed, _reconnectConnector } = useGrazStore();
+  const { _reconnect, _onReconnectFailed, _reconnectConnector } = useGrazInternalStore();
+  const { activeChain } = useGrazSessionStore();
 
   useEffect(() => {
     // will reconnect on refresh

--- a/packages/graz/src/provider/index.tsx
+++ b/packages/graz/src/provider/index.tsx
@@ -1,9 +1,11 @@
 import type { QueryClientProviderProps } from "@tanstack/react-query";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import type { FC } from "react";
 
 import type { ConfigureGrazArgs } from "../actions/configure";
 import { configureGraz } from "../actions/configure";
+import { ClientOnly } from "./client-only";
 import { GrazEvents } from "./events";
 
 const queryClient = new QueryClient({
@@ -12,6 +14,7 @@ const queryClient = new QueryClient({
 
 export type GrazProviderProps = Partial<QueryClientProviderProps> & {
   grazOptions?: ConfigureGrazArgs;
+  debug?: boolean;
 };
 
 /**
@@ -32,14 +35,17 @@ export type GrazProviderProps = Partial<QueryClientProviderProps> & {
  *
  * @see https://tanstack.com/query
  */
-export const GrazProvider: FC<GrazProviderProps> = ({ children, grazOptions, ...props }) => {
+export const GrazProvider: FC<GrazProviderProps> = ({ children, grazOptions, debug, ...props }) => {
   if (grazOptions) {
     configureGraz(grazOptions);
   }
   return (
     <QueryClientProvider client={queryClient} {...props}>
-      <GrazEvents />
-      {children}
+      <ClientOnly>
+        <GrazEvents />
+        {children}
+      </ClientOnly>
+      {debug ? <ReactQueryDevtools initialIsOpen={false} position="bottom-right" /> : null}
     </QueryClientProvider>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,10 @@ importers:
         version: 0.11.64
       '@tanstack/react-query':
         specifier: ^4.29.11
-        version: 4.29.11(react@18.2.0)
+        version: 4.29.11(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^4.29.12
+        version: 4.29.12(@tanstack/react-query@4.29.11)(react-dom@18.2.0)(react@18.2.0)
       '@walletconnect/sign-client':
         specifier: ^2.7.7
         version: 2.7.7
@@ -5235,11 +5238,33 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
+  /@tanstack/match-sorter-utils@8.8.4:
+    resolution: {integrity: sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==}
+    engines: {node: '>=12'}
+    dependencies:
+      remove-accents: 0.4.2
+    dev: false
+
   /@tanstack/query-core@4.29.11:
     resolution: {integrity: sha512-8C+hF6SFAb/TlFZyS9FItgNwrw4PMa7YeX+KQYe2ZAiEz6uzg6yIr+QBzPkUwZ/L0bXvGd1sufTm3wotoz+GwQ==}
     dev: false
 
-  /@tanstack/react-query@4.29.11(react@18.2.0):
+  /@tanstack/react-query-devtools@4.29.12(@tanstack/react-query@4.29.11)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ug4YGQhMhh6QI8/sWJhjXxuvdeehxf1cyxpTifGMH5qreQ5ECHT6vzqG/aKvADQDzqLBGrF0q4wTDnRRYvvtrA==}
+    peerDependencies:
+      '@tanstack/react-query': 4.29.12
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@tanstack/match-sorter-utils': 8.8.4
+      '@tanstack/react-query': 4.29.11(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      superjson: 1.12.3
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
+
+  /@tanstack/react-query@4.29.11(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aLaOAhBnCr12YKPjDsZOc0fAtkyaW7f9KfVfw49oYpfe0H9EPXBUgDBIKJ8qdHF3uGzTVSMcmpiw1Za41BLZlw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5253,6 +5278,7 @@ packages:
     dependencies:
       '@tanstack/query-core': 4.29.11
       react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
@@ -7127,6 +7153,13 @@ packages:
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.11
     dev: false
 
   /copy-text-to-clipboard@3.1.0:
@@ -9908,6 +9941,11 @@ packages:
       get-intrinsic: 1.2.1
     dev: true
 
+  /is-what@4.1.11:
+    resolution: {integrity: sha512-gr9+qDrJvdwT4+N2TAACsZQIB4Ow9j2eefqlh3m9JUV41M1LoKhcE+/j+IVni/r6U8Jnc1PwhjdjVJr+Xmtb0A==}
+    engines: {node: '>=12.13'}
+    dev: false
+
   /is-whitespace-character@1.0.4:
     resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==}
     dev: false
@@ -12335,6 +12373,10 @@ packages:
       mdast-squeeze-paragraphs: 4.0.0
     dev: false
 
+  /remove-accents@0.4.2:
+    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
+    dev: false
+
   /renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
     dependencies:
@@ -13113,6 +13155,13 @@ packages:
       pirates: 4.0.5
       ts-interface-checker: 0.1.13
     dev: true
+
+  /superjson@1.12.3:
+    resolution: {integrity: sha512-0j+U70KUtP8+roVPbwfqkyQI7lBt7ETnuA7KXbTDX3mCKiD/4fXs2ldKSMdt0MCfpTwiMxo20yFU3vu6ewETpQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      copy-anything: 3.0.5
+    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}


### PR DESCRIPTION
This PR is for splitting graz internal store and account store

- internal store uses local storage
- account(session) store uses session storage
- wrap provider with ClientOnly component to prevent hydration error
- add devtools debug in provider