### PR TITLE
Support iframe connection

### DIFF
--- a/docs/docs/hooks/useCheckWallet.md
+++ b/docs/docs/hooks/useCheckWallet.md
@@ -25,6 +25,7 @@ const { data: isKeplrSupported } = useCheckWallet(WalletType.KEPLR);
     WC_LEAP_MOBILE = "wc_leap_mobile",
     WC_COSMOSTATION_MOBILE = "wc_cosmostation_mobile",
     METAMASK_SNAP_LEAP = "metamask_snap_leap",
+    COSMIFRAME = "cosmiframe",
   }
   ```
 
@@ -41,6 +42,7 @@ const { data: isKeplrSupported } = useCheckWallet(WalletType.KEPLR);
     WalletTyoe.WC_LEAP_MOBILE,
     WalletTyoe.WC_COSMOSTATION_MOBILE,
     WalletTyoe.METAMASK_SNAP_LEAP,
+    WalletType.COSMIFRAME,
   }
   ```
 

--- a/docs/docs/types/walletType.md
+++ b/docs/docs/types/walletType.md
@@ -49,5 +49,6 @@ enum WalletType {
   STATION = "station",
   XDEFI = "xdefi",
   CAPSULE = "capsule",
+  COSMIFRAME = "cosmiframe",
 }
 ```

--- a/example/next/ui/connect-button.tsx
+++ b/example/next/ui/connect-button.tsx
@@ -85,6 +85,9 @@ export const ConnectButton: FC = () => {
               <Button onClick={() => handleConnect(WalletType.METAMASK_SNAP_COSMOS)}>Metamask Snap Cosmos</Button>
             ) : null}
             {wallets.capsule ? <Button onClick={() => handleConnect(WalletType.CAPSULE)}>Capsule</Button> : null}
+            {wallets.cosmiframe ? (
+              <Button onClick={() => handleConnect(WalletType.COSMIFRAME)}>Cosmiframe</Button>
+            ) : null}
           </Stack>
         </ModalContent>
       </Modal>

--- a/example/starter/src/utils/graz.ts
+++ b/example/starter/src/utils/graz.ts
@@ -65,4 +65,8 @@ export const listedWallets = {
     name: "Capsule",
     imgSrc: "/assets/wallet-icon-capsule.jpg",
   },
+  [WalletType.COSMIFRAME]: {
+    name: "Cosmiframe",
+    imgSrc: "",
+  },
 };

--- a/packages/graz/package.json
+++ b/packages/graz/package.json
@@ -42,6 +42,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
+    "@cosmjs/amino": "*",
     "@cosmjs/cosmwasm-stargate": "*",
     "@cosmjs/launchpad": "*",
     "@cosmjs/proto-signing": "*",
@@ -52,6 +53,7 @@
   },
   "dependencies": {
     "@cosmsnap/snapper": "^0.1.29",
+    "@dao-dao/cosmiframe": "^0.0.4",
     "@keplr-wallet/cosmos": "^0.12.20",
     "@keplr-wallet/types": "^0.12.23",
     "@metamask/providers": "^12.0.0",

--- a/packages/graz/src/actions/wallet/cosmiframe.ts
+++ b/packages/graz/src/actions/wallet/cosmiframe.ts
@@ -1,0 +1,38 @@
+import { Cosmiframe } from "@dao-dao/cosmiframe";
+
+import { useGrazInternalStore } from "../../store";
+import type { Wallet } from "../../types/wallet";
+
+/**
+ * Function to return {@link Wallet} object and throws and error if not in an iframe.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   const cosmiframe = getCosmiframe();
+ * } catch (error: Error) {
+ *   console.error(error.message);
+ * }
+ * ```
+ *
+ *
+ */
+export const getCosmiframe = (): Wallet => {
+  if (window.parent === window.self) {
+    useGrazInternalStore.getState()._notFoundFn();
+    throw new Error("not in iframe");
+  }
+
+  const keplr = new Cosmiframe().getKeplrClient();
+
+  return {
+    enable: keplr.enable.bind(keplr),
+    getKey: keplr.getKey.bind(keplr),
+    getOfflineSigner: keplr.getOfflineSigner.bind(keplr),
+    getOfflineSignerAuto: keplr.getOfflineSignerAuto.bind(keplr),
+    getOfflineSignerOnlyAmino: keplr.getOfflineSignerOnlyAmino.bind(keplr),
+    experimentalSuggestChain: keplr.experimentalSuggestChain.bind(keplr),
+    signDirect: keplr.signDirect.bind(keplr),
+    signAmino: keplr.signAmino.bind(keplr),
+  };
+};

--- a/packages/graz/src/actions/wallet/index.ts
+++ b/packages/graz/src/actions/wallet/index.ts
@@ -3,6 +3,7 @@ import { grazSessionDefaultValues, useGrazInternalStore, useGrazSessionStore } f
 import type { Wallet } from "../../types/wallet";
 import { WALLET_TYPES, WalletType } from "../../types/wallet";
 import { getCapsule } from "./capsule";
+import { getCosmiframe } from "./cosmiframe";
 import { getMetamaskSnapCosmos } from "./cosmos-metamask-snap";
 import { getCosmostation } from "./cosmostation";
 import { getKeplr } from "./keplr";
@@ -92,6 +93,9 @@ export const getWallet = (type: WalletType = useGrazInternalStore.getState().wal
       }
       case WalletType.CAPSULE: {
         return getCapsule();
+      }
+      case WalletType.COSMIFRAME: {
+        return getCosmiframe();
       }
       default: {
         throw new Error("Unknown wallet type");

--- a/packages/graz/src/hooks/wallet.ts
+++ b/packages/graz/src/hooks/wallet.ts
@@ -30,6 +30,7 @@ export const useActiveWalletType = () => {
       isMetamaskSnapLeap: x.walletType === WalletType.METAMASK_SNAP_LEAP,
       isStation: x.walletType === WalletType.STATION,
       isCapsule: x.walletType === WalletType.CAPSULE,
+      isCosmiframe: x.walletType === WalletType.COSMIFRAME,
     }),
     shallow,
   );

--- a/packages/graz/src/provider/events.tsx
+++ b/packages/graz/src/provider/events.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { reconnect } from "../actions/account";
 import { checkWallet } from "../actions/wallet";
+import { getCosmiframe } from "../actions/wallet/cosmiframe";
 import { getCosmostation } from "../actions/wallet/cosmostation";
 import { getKeplr } from "../actions/wallet/keplr";
 import { getLeap } from "../actions/wallet/leap";
@@ -84,6 +85,11 @@ export const useGrazEvents = () => {
       }
       if (_reconnectConnector === WalletType.XDEFI) {
         getXDefi().subscription?.(() => {
+          void reconnect({ onError: _onReconnectFailed });
+        });
+      }
+      if (_reconnectConnector === WalletType.COSMIFRAME) {
+        getCosmiframe().subscription?.(() => {
           void reconnect({ onError: _onReconnectFailed });
         });
       }

--- a/packages/graz/src/types/wallet.ts
+++ b/packages/graz/src/types/wallet.ts
@@ -19,6 +19,7 @@ export enum WalletType {
   STATION = "station",
   XDEFI = "xdefi",
   CAPSULE = "capsule",
+  COSMIFRAME = "cosmiframe",
 }
 
 export const WALLET_TYPES = [
@@ -35,6 +36,7 @@ export const WALLET_TYPES = [
   WalletType.XDEFI,
   WalletType.CAPSULE,
   WalletType.METAMASK_SNAP_COSMOS,
+  WalletType.COSMIFRAME,
 ];
 
 export type Wallet = Pick<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
 
   packages/graz:
     dependencies:
+      '@cosmjs/amino':
+        specifier: '*'
+        version: 0.31.3
       '@cosmjs/cosmwasm-stargate':
         specifier: '*'
         version: 0.31.0
@@ -230,6 +233,9 @@ importers:
       '@cosmsnap/snapper':
         specifier: ^0.1.29
         version: 0.1.29
+      '@dao-dao/cosmiframe':
+        specifier: ^0.0.4
+        version: 0.0.4(@cosmjs/amino@0.31.3)(@cosmjs/proto-signing@0.31.0)
       '@keplr-wallet/cosmos':
         specifier: ^0.12.20
         version: 0.12.20
@@ -4497,7 +4503,7 @@ packages:
   /@cosmjs/cosmwasm-stargate@0.31.0:
     resolution: {integrity: sha512-l6aX++3LhaAGZO46qIgrrNF40lYhOrdPfl35Z32ks6Wf3mwgbQEZwaxnoGzwUePY7/yaIiEFJ1JO6MlVPZVuag==}
     dependencies:
-      '@cosmjs/amino': 0.31.0
+      '@cosmjs/amino': 0.31.3
       '@cosmjs/crypto': 0.31.0
       '@cosmjs/encoding': 0.31.0
       '@cosmjs/math': 0.31.0
@@ -4754,7 +4760,7 @@ packages:
   /@cosmjs/proto-signing@0.31.0:
     resolution: {integrity: sha512-JNlyOJRkn8EKB9mCthkjr6lVX6eyVQ09PFdmB4/DR874E62dFTvQ+YvyKMAgN7K7Dcjj26dVlAD3f6Xs7YOGDg==}
     dependencies:
-      '@cosmjs/amino': 0.31.0
+      '@cosmjs/amino': 0.31.3
       '@cosmjs/crypto': 0.31.0
       '@cosmjs/encoding': 0.31.0
       '@cosmjs/math': 0.31.0
@@ -4890,7 +4896,7 @@ packages:
     resolution: {integrity: sha512-GYhk9lzZPj/QmYHC0VV/4AMoRzVcOP+EnB1YZCoWlBdLuVmpBYKRagJqWIrIwdk1E0gF2ZoESd2TYfdh1fqIpg==}
     dependencies:
       '@confio/ics23': 0.6.8
-      '@cosmjs/amino': 0.31.0
+      '@cosmjs/amino': 0.31.3
       '@cosmjs/encoding': 0.31.0
       '@cosmjs/math': 0.31.0
       '@cosmjs/proto-signing': 0.31.0
@@ -5038,6 +5044,17 @@ packages:
       '@keplr-wallet/proto-types': 0.12.12
       '@keplr-wallet/types': 0.12.12
       ses: 0.18.4
+    dev: false
+
+  /@dao-dao/cosmiframe@0.0.4(@cosmjs/amino@0.31.3)(@cosmjs/proto-signing@0.31.0):
+    resolution: {integrity: sha512-EmzhIRsuGBZhDIWsWzvPFHpQRnnBRj3Cprhp5xSL+trnd1ESadCbIF8sobgSUHrifnPPvF9DTIrnm5RIbuBKhg==}
+    peerDependencies:
+      '@cosmjs/amino': '>= ^0.32'
+      '@cosmjs/proto-signing': '>= ^0.32'
+    dependencies:
+      '@cosmjs/amino': 0.31.3
+      '@cosmjs/proto-signing': 0.31.0
+      uuid: 9.0.1
     dev: false
 
   /@discoveryjs/json-ext@0.5.7:
@@ -15429,6 +15446,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
     dev: false
@@ -23286,7 +23304,3 @@ packages:
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR adds support for the iframe-passthrough wallet connection originally developed for Cosmos Kit and used primarily by DAO DAO. This is accomplished by integrating the [cosmiframe](https://github.com/DA0-DA0/cosmiframe) package.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

- [x] Added Cosmiframe wallet that only shows up when inside of an iframe
