### PR TITLE
Fetch all keys from wallet instead of transforming bech32

### DIFF
--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -1,4 +1,3 @@
-import { fromBech32, toBech32 } from "@cosmjs/encoding";
 import type { OfflineDirectSigner } from "@cosmjs/proto-signing";
 import type { ChainInfo, Key, OfflineAminoSigner } from "@keplr-wallet/types";
 
@@ -67,17 +66,11 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
       const _resAcc = useGrazSessionStore.getState().accounts;
       useGrazSessionStore.setState({ status: "connecting" });
 
-      const key = await wallet.getKey(chainIds[0]!);
-      const resultAcccounts: Record<string, Key> = {};
-      chainIds.forEach((chainId) => {
-        resultAcccounts[chainId] = {
-          ...key,
-          bech32Address: toBech32(
-            chains!.find((x) => x.chainId === chainId)!.bech32Config.bech32PrefixAccAddr,
-            fromBech32(key.bech32Address).data,
-          ),
-        };
-      });
+      const resultAcccounts = Object.fromEntries(
+        await Promise.all(
+          chainIds.map(async (chainId): Promise<[string, Key]> => [chainId, await wallet.getKey(chainId)]),
+        ),
+      );
       useGrazSessionStore.setState((prev) => ({
         accounts: { ...(prev.accounts || {}), ...resultAcccounts },
       }));
@@ -105,17 +98,11 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
       return { accounts: _resAcc!, walletType: currentWalletType, chains: connectedChains };
     }
     if (!isWalletConnect(currentWalletType)) {
-      const key = await wallet.getKey(chainIds[0]!);
-      const resultAcccounts: Record<string, Key> = {};
-      chainIds.forEach((chainId) => {
-        resultAcccounts[chainId] = {
-          ...key,
-          bech32Address: toBech32(
-            chains!.find((x) => x.chainId === chainId)!.bech32Config.bech32PrefixAccAddr,
-            fromBech32(key.bech32Address).data,
-          ),
-        };
-      });
+      const resultAcccounts = Object.fromEntries(
+        await Promise.all(
+          chainIds.map(async (chainId): Promise<[string, Key]> => [chainId, await wallet.getKey(chainId)]),
+        ),
+      );
       useGrazSessionStore.setState((prev) => ({
         accounts: { ...(prev.accounts || {}), ...resultAcccounts },
       }));

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -297,17 +297,9 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     try {
       await promiseWithTimeout(
         (async () => {
-          const wcAccount = await getKey(chainId[0]!);
-          const resultAcccounts: Record<string, Key> = {};
-          chainId.forEach((x) => {
-            resultAcccounts[x] = {
-              ...wcAccount,
-              bech32Address: toBech32(
-                chains!.find((y) => y.chainId === x)!.bech32Config.bech32PrefixAccAddr,
-                fromBech32(wcAccount.bech32Address).data,
-              ),
-            };
-          });
+          const resultAcccounts = Object.fromEntries(
+            await Promise.all(chainId.map(async (c): Promise<[string, Key]> => [c, await getKey(c)])),
+          );
           useGrazSessionStore.setState({
             accounts: resultAcccounts,
           });


### PR DESCRIPTION
Some chains use different coin types, and thus different wallet derivation paths and public keys. For example, Terra and Juno have different coin types, so their bech32 data is different for the same private key.

Essentially, bech32 addresses should never be converted into one another. This PR removes an unnecessary conversion and fetches all accounts from the wallet.