### PR TITLE
Clot mobile wallet support

### DIFF
--- a/example/next/ui/connect-button.tsx
+++ b/example/next/ui/connect-button.tsx
@@ -77,6 +77,9 @@ export const ConnectButton: FC = () => {
             {wallets.wc_cosmostation_mobile ? (
               <Button onClick={() => handleConnect(WalletType.WC_COSMOSTATION_MOBILE)}>Cosmostation Mobile</Button>
             ) : null}
+            {wallets.wc_clot_mobile ? (
+              <Button onClick={() => handleConnect(WalletType.WC_CLOT_MOBILE)}>Clot Mobile</Button>
+            ) : null}
             {wallets.station ? <Button onClick={() => handleConnect(WalletType.STATION)}>Station</Button> : null}
             {wallets.metamask_snap_leap ? (
               <Button onClick={() => handleConnect(WalletType.METAMASK_SNAP_LEAP)}>Metamask Snap Leap</Button>

--- a/packages/graz/src/actions/wallet/index.ts
+++ b/packages/graz/src/actions/wallet/index.ts
@@ -15,6 +15,7 @@ import { getWalletConnect } from "./wallet-connect";
 import { getWCCosmostation } from "./wallet-connect/cosmostation";
 import { getWCKeplr } from "./wallet-connect/keplr";
 import { getWCLeap } from "./wallet-connect/leap";
+import { getWCClot } from "./wallet-connect/clot";
 import { getXDefi } from "./xdefi";
 
 /**
@@ -78,6 +79,9 @@ export const getWallet = (type: WalletType = useGrazInternalStore.getState().wal
       }
       case WalletType.WC_COSMOSTATION_MOBILE: {
         return getWCCosmostation();
+      }
+      case WalletType.WC_CLOT_MOBILE: {
+        return getWCClot();
       }
       case WalletType.METAMASK_SNAP_LEAP: {
         return getMetamaskSnapLeap();

--- a/packages/graz/src/actions/wallet/wallet-connect/clot.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/clot.ts
@@ -1,0 +1,36 @@
+import { useGrazInternalStore } from "../../../store";
+import type { Wallet } from "../../../types/wallet";
+import { WalletType } from "../../../types/wallet";
+import { isMobile } from "../../../utils/os";
+import { getWalletConnect } from ".";
+import type { GetWalletConnectParams } from "./types";
+
+export const getWCClot = (): Wallet => {
+  if (!useGrazInternalStore.getState().walletConnect?.options?.projectId?.trim()) {
+    throw new Error("walletConnect.options.projectId is not defined");
+  }
+
+  if (!isMobile()) throw new Error("WalletConnect Clot mobile is only supported in mobile");
+
+  const params: GetWalletConnectParams = {
+    encoding: "base64",
+    appUrl: {
+      mobile: {
+        ios: "clot://",
+      },
+    },
+    walletType: WalletType.WC_CLOT_MOBILE,
+    formatNativeUrl: (appUrl, wcUri, os) => {
+      const plainAppUrl = appUrl.replaceAll("/", "").replaceAll(":", "");
+      const encoded = encodeURIComponent(wcUri);
+      switch (os) {
+        case "ios":
+          return `${plainAppUrl}://wcV2?${encoded}`;
+        default:
+          return `${plainAppUrl}://wc?uri=${encoded}`;
+      }
+    },
+  };
+
+  return getWalletConnect(params);
+};

--- a/packages/graz/src/actions/wallet/wallet-connect/types.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/types.ts
@@ -16,7 +16,7 @@ export interface WalletConnectSignDirectResponse {
 
 export interface GetWalletConnectParams {
   encoding: BufferEncoding;
-  walletType: WalletType.WC_KEPLR_MOBILE | WalletType.WC_LEAP_MOBILE | WalletType.WC_COSMOSTATION_MOBILE;
+  walletType: WalletType.WC_KEPLR_MOBILE | WalletType.WC_LEAP_MOBILE | WalletType.WC_COSMOSTATION_MOBILE | WalletType.WC_CLOT_MOBILE;
   appUrl: {
     mobile: {
       ios: string;

--- a/packages/graz/src/types/wallet.ts
+++ b/packages/graz/src/types/wallet.ts
@@ -13,6 +13,8 @@ export enum WalletType {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   WC_COSMOSTATION_MOBILE = "wc_cosmostation_mobile",
   // eslint-disable-next-line @typescript-eslint/naming-convention
+  WC_CLOT_MOBILE = "wc_clot_mobile",
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   METAMASK_SNAP_LEAP = "metamask_snap_leap",
   // eslint-disable-next-line @typescript-eslint/naming-convention
   METAMASK_SNAP_COSMOS = "metamask_snap_cosmos",
@@ -31,6 +33,7 @@ export const WALLET_TYPES = [
   WalletType.WC_KEPLR_MOBILE,
   WalletType.WC_LEAP_MOBILE,
   WalletType.WC_COSMOSTATION_MOBILE,
+  WalletType.WC_CLOT_MOBILE,
   WalletType.METAMASK_SNAP_LEAP,
   WalletType.STATION,
   WalletType.XDEFI,


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

- WC_CLOT_MOBILE WalletType
- `getWCClot` method
- Clot mobile connect button

## Additional info
Clot Wallet AppStore URL [link](https://apps.apple.com/gb/app/clot-wallet/id1584113315)
Main use case: connecting with stargaze.zone using WalletConnectV2 protocol