### PR TITLE
Fix Next.JS SSR not working when wrapped with GrazProvider

### DIFF
--- a/packages/graz/src/provider/index.tsx
+++ b/packages/graz/src/provider/index.tsx
@@ -38,8 +38,8 @@ export const GrazProvider: FC<GrazProviderProps> = ({ children, grazOptions, ...
 
   return (
     <QueryClientProvider key="graz-provider" client={queryClient} {...props}>
+      {children}
       <ClientOnly>
-        {children}
         <GrazEvents />
       </ClientOnly>
     </QueryClientProvider>


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This change allows the Next.js app to work with SSR. When the {children} in GrazProvider is a child of ClientOnly component, it's not rendered in the Next.js server, so the client never receives the page with the content initially, only after the client-side JS is loaded.

## Checklist

- [ ] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

## Changes

- [ ] Added ...
- [x] Changed ...
- [ ] Removed ...

## Screenshots

...

## Testing

- Open page ...
- Click ...
- Make sure that ...

## Links/References

- ...
- ...
- ...

## Notes

- ...
- ...
- ...
