### PR TITLE
Ensure that coinGeckoId is not an empty string

### DIFF
--- a/packages/graz/src/cli.mjs
+++ b/packages/graz/src/cli.mjs
@@ -238,7 +238,7 @@ const makeRecord = async (client, { filter = "" } = {}) => {
             coinMinimalDenom:
               chain.assets?.find((asset) => asset.denom === token.denom)?.denom_units[0]?.denom || token.denom,
             coinDecimals: Number(chain.assets?.find((asset) => asset.denom === token.denom)?.decimals),
-            coinGeckoId: chain.assets?.find((asset) => asset.denom === token.denom)?.coingecko_id || "",
+            coinGeckoId: chain.assets?.find((asset) => asset.denom === token.denom)?.coingecko_id || undefined,
             gasPriceStep: {
               low: Number(token.low_gas_price),
               average: Number(token.average_gas_price),
@@ -252,7 +252,7 @@ const makeRecord = async (client, { filter = "" } = {}) => {
           coinMinimalDenom:
             chain.assets?.find((asset) => asset.denom === token.denom)?.denom_units[0]?.denom || token.denom,
           coinDecimals: Number(chain.assets?.find((asset) => asset.denom === token.denom)?.decimals),
-          coinGeckoId: chain.assets?.find((asset) => asset.denom === token.denom)?.coingecko_id || "",
+          coinGeckoId: chain.assets?.find((asset) => asset.denom === token.denom)?.coingecko_id || undefined,
         };
       });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR updates the cli generation to ensure that `coinGeckoId` does not provide an empty string because this errors in Keplr wallet.

```
feeCurrencies[0].coinGeckoId" is not allowed to be empty
app-index.js:33 Error: "feeCurrencies[0].coinGeckoId" is not allowed to be empty
    at n (injectedScript.bundle.js:2:167714)
```

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

- [ ] Added ...
- [x] Changed cli.js
- [ ] Removed ...

## Screenshots

...

## Testing

- Open page ...
- Click ...
- Make sure that ...

## Links/References

- ...
- ...
- ...

## Notes

- ...
- ...
- ...
